### PR TITLE
update for retaining the IP Adr of recent sensor.

### DIFF
--- a/ini.py
+++ b/ini.py
@@ -117,6 +117,16 @@ def getPreviousMachineFile(iniFile):
 
     return machineFilePath
 
+def getPreviousIPAddress(iniFile) -> "data/previousIPAddress.ini":
+    # if not exist IPadr iniFile, return default IPadr
+    try:
+        config = configparser.ConfigParser()
+        config.read(iniFile)
+        IPAddress = config.get('previous_IPadr', 'IP_Address')
+    except:
+        IPAddress = "127.0.0.1" # default
+    return IPAddress
+
 def getPreviousPostProcFile(iniFile):
     config = configparser.ConfigParser()
     config.read(iniFile)
@@ -142,6 +152,16 @@ def updatePreviousPostProcFile(iniFile, postprocFile):
     section = 'previous_postproc'
     config_ps.add_section(section)
     config_ps.set(section, 'postproc_file', postprocFile)
+
+    with open(iniFile, 'w') as configfile:
+        config_ps.write(configfile)
+
+def updatePreviousIPAddressFile(iniFile, IPadr):
+    config_ps = configparser.RawConfigParser()
+
+    section = 'previous_IPadr'
+    config_ps.add_section(section)
+    config_ps.set(section, "IP_address", IPadr)
 
     with open(iniFile, 'w') as configfile:
         config_ps.write(configfile)

--- a/sensors.py
+++ b/sensors.py
@@ -23,6 +23,7 @@ import subprocess
 app = QtWidgets.qApp
 
 from qtutils import inmain
+import ini
 
 # xのあるbit位置が0か1か調べる
 def getbit(x, b):
@@ -106,8 +107,7 @@ class SensorWindow(QtWidgets.QDockWidget):  # https://teratail.com/questions/118
 
         # Variables (initialized with default values)
         # insert privious connected Sensor IP from saveFile
-        with open("data/recentConnectedIPAddress.txt",mode='r', encoding='UTF-8') as f:
-            self.IPaddress = f.read().replace('\n', '')
+        self.IPaddress = ini.getPreviousIPAddress('data/previousIPAddress.ini')
         self.portNum: int = 8888
         self.shutterSpeed: int = 30000
         self.frames: int = 5
@@ -241,9 +241,8 @@ class SensorWindow(QtWidgets.QDockWidget):  # https://teratail.com/questions/118
             self.portNum = int(d.group(2))
         else:
             self.IPaddress = self.RPiaddress
-        # write changed IP address to saveFile
-        with open("data/recentConnectedIPAddress.txt", mode="+w", encoding='UTF-8') as f:
-            print(self.IPaddress, file=f)
+        # write changed IP address to inifile
+        ini.updatePreviousIPAddressFile("data/previousIPAddress.ini", self.IPaddress)
 
 
     def changeShutter(self):


### PR DESCRIPTION
・sensorwindow内のIPコンボボックスが、前回接続したセンサのIPアドレスを保持するようにしました。
・IPアドレスの保持は「MkECTL/data/recentConnectedAddress.txt」が担っています。
・MkECTLを落とし再度起動後、アドレスの保持を確認しています。

[懸念点]
・接続に失敗しても、そのIPアドレスを保持する。