### PR TITLE
Fix histogram dialog QImage copy

### DIFF
--- a/image_stats_dialog.py
+++ b/image_stats_dialog.py
@@ -74,9 +74,11 @@ class ImageStatsDialog(QDialog):
         qimage = qimage.convertToFormat(QImage.Format.Format_Grayscale8)
         width = qimage.width()
         height = qimage.height()
+        bytes_per_line = qimage.bytesPerLine()
         ptr = qimage.bits()
-        ptr.setsize(width * height)
-        return np.frombuffer(ptr, np.uint8).reshape((height, width))
+        ptr.setsize(bytes_per_line * height)
+        arr = np.frombuffer(ptr, np.uint8).reshape((height, bytes_per_line))
+        return arr[:, :width].copy()
 
     def show_histogram(self, arr: np.ndarray):
         bins = np.arange(257)


### PR DESCRIPTION
## Summary
- ensure `qimage_to_array` copies pixel data out of `QImage`

## Testing
- `python3 -m py_compile image_stats_dialog.py`
- manual script to verify array independence from source `QImage`

------
https://chatgpt.com/codex/tasks/task_e_68515976289883338fac18687ca5aae9