### PR TITLE
Fix qApp usage for PySide6

### DIFF
--- a/MkECTL.py
+++ b/MkECTL.py
@@ -118,7 +118,7 @@ class Ui(QMainWindow, IMainUI):
         self.ui.stopButton.clicked.connect(self.interrupt)
 
         # 画面サイズを取得 (a.desktop()は QDesktopWidget )  https://ja.stackoverflow.com/questions/44060/pyqt5%E3%81%A7%E3%82%A6%E3%82%A3%E3%83%B3%E3%83%89%E3%82%A6%E3%82%92%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%BC%E3%83%B3%E3%81%AE%E4%B8%AD%E5%A4%AE%E3%81%AB%E8%A1%A8%E7%A4%BA%E3%81%97%E3%81%9F%E3%81%84
-        a = qApp
+        a = QtWidgets.QApplication.instance()
         desktop = a.desktop()
         self.geometry = desktop.screenGeometry()
         # ウインドウサイズ(枠込)を取得

--- a/execute_script.py
+++ b/execute_script.py
@@ -43,7 +43,7 @@ dynvars = {
             'datetime': 't'
             }
 
-app = QtWidgets.qApp
+app = QtWidgets.QApplication.instance()
 isDemo = False
 
 class Systate():

--- a/sensors.py
+++ b/sensors.py
@@ -21,7 +21,7 @@ from SensorInfo import SensorInfo
 from PIL import Image, ImageQt
 import subprocess
 
-app = QtWidgets.qApp
+app = QtWidgets.QApplication.instance()
 
 from qtutils import inmain
 import ini


### PR DESCRIPTION
## Summary
- replace deprecated QtWidgets.qApp references with `QApplication.instance()`
- update MkECTL to use `QtWidgets.QApplication.instance()` when obtaining screen information

## Testing
- `pip install PySide6`
- `python3 MkECTL.py` *(fails: ImportError: libEGL.so.1)*

------
https://chatgpt.com/codex/tasks/task_e_6853c64990c48333bce9fba2bebaa4ea