### PR TITLE
Fix PySide6 QGuiApplication call

### DIFF
--- a/MkECTL.py
+++ b/MkECTL.py
@@ -118,7 +118,9 @@ class Ui(QMainWindow, IMainUI):
         self.ui.stopButton.clicked.connect(self.interrupt)
 
         # 画面サイズを取得
-        screen = QtGui.QGuiApplication.primaryScreen()
+        # PySide6 では QtGui モジュールを名前空間として使用しないため
+        # QGuiApplication を直接参照する
+        screen = QGuiApplication.primaryScreen()
         self.geometry = screen.availableGeometry()
         # ウインドウサイズ(枠込)を取得
         self.framesize = self.frameSize()


### PR DESCRIPTION
## Summary
- fix NameError when creating Ui by calling QGuiApplication.primaryScreen directly

## Testing
- `python3 MkECTL.py` *(fails: libEGL.so.1 missing)*

------
https://chatgpt.com/codex/tasks/task_e_6853cb81b2f48333aed2228604da114b