### PR TITLE
Fix qtutils version for PySide6

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ Clone the repository and install the dependencies with:
 pip install -r requirements.txt
 ```
 
+PySide6 を利用するには `qtutils` のバージョン `4.0.0` 以上が必要です。
+requirements.txt を更新後は最新版が入っていることを確認してください。
+
 Linux 環境で実行する場合は Qt の xcb プラットフォームプラグインに必要なパッケージ
 `libxcb-cursor0` を追加でインストールしてください。これがないと
 `xcb-cursor0 or libxcb-cursor0 is needed to load the Qt xcb platform plugin` という

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ pyserial
 timeout-decorator
 PyGObject
 playsound
-qtutils
+qtutils>=4.0.0
 ssdpy
 psutil
 pymkeapi>=1.3.6

--- a/spec_MkECTL.md
+++ b/spec_MkECTL.md
@@ -14,6 +14,7 @@
 * Linux 環境では `libxcb-cursor0` が必要です。未インストールの場合は
   `xcb-cursor0 or libxcb-cursor0 is needed to load the Qt xcb platform plugin`
   というエラーが発生します。
+* PySide6 で `qtutils` を利用するにはバージョン `4.0.0` 以上が必要です。
 
 ## サンプル
 ```dsl


### PR DESCRIPTION
## Summary
- require `qtutils>=4.0.0`
- document qtutils version requirement in README and spec

## Testing
- `python -m py_compile sensors.py`

------
https://chatgpt.com/codex/tasks/task_e_6853e70168fc8333acc568357dd0166b