### PR TITLE
Fix smoothing toggle and swap checkbox layout

### DIFF
--- a/ImageViewScene.py
+++ b/ImageViewScene.py
@@ -215,6 +215,7 @@ class ImageViewer(QtWidgets.QGraphicsView):
         self._smoothing = enable
         self._update_render_hints()
         self._update_transform_mode()
+        self.viewport().update()
 
     def is_smoothing_enabled(self) -> bool:
         return self._smoothing

--- a/sensorwindow_dock.ui
+++ b/sensorwindow_dock.ui
@@ -58,6 +58,16 @@
          </widget>
         </item>
         <item>
+        <widget class="QCheckBox" name="smoothingCheckBox">
+          <property name="text">
+           <string>Smooth</string>
+          </property>
+          <property name="checked">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item>
         <widget class="QPushButton" name="statsButton">
           <property name="text">
            <string/>
@@ -68,16 +78,6 @@
           </property>
           <property name="flat">
            <bool>false</bool>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QCheckBox" name="smoothingCheckBox">
-          <property name="text">
-           <string>Smooth</string>
-          </property>
-          <property name="checked">
-           <bool>true</bool>
           </property>
          </widget>
         </item>

--- a/sensorwindow_dock_ui.py
+++ b/sensorwindow_dock_ui.py
@@ -59,6 +59,12 @@ class Ui_sensor(object):
 
         self.horizontalLayout_2.addWidget(self.cameraStatusLabel)
 
+        self.smoothingCheckBox = QCheckBox(self.dockWidgetContents)
+        self.smoothingCheckBox.setObjectName(u"smoothingCheckBox")
+        self.smoothingCheckBox.setChecked(True)
+
+        self.horizontalLayout_2.addWidget(self.smoothingCheckBox)
+
         self.statsButton = QPushButton(self.dockWidgetContents)
         self.statsButton.setObjectName(u"statsButton")
         icon = QIcon()
@@ -67,12 +73,6 @@ class Ui_sensor(object):
         self.statsButton.setFlat(False)
 
         self.horizontalLayout_2.addWidget(self.statsButton)
-
-        self.smoothingCheckBox = QCheckBox(self.dockWidgetContents)
-        self.smoothingCheckBox.setObjectName(u"smoothingCheckBox")
-        self.smoothingCheckBox.setChecked(True)
-
-        self.horizontalLayout_2.addWidget(self.smoothingCheckBox)
 
         self.homeButton = QPushButton(self.dockWidgetContents)
         self.homeButton.setObjectName(u"homeButton")
@@ -747,8 +747,8 @@ class Ui_sensor(object):
     def retranslateUi(self, sensor):
         sensor.setWindowTitle(QCoreApplication.translate("sensor", u"Sensor Window", None))
         self.cameraStatusLabel.setText(QCoreApplication.translate("sensor", u"CAMERA STATE", None))
-        self.statsButton.setText("")
         self.smoothingCheckBox.setText(QCoreApplication.translate("sensor", u"Smooth", None))
+        self.statsButton.setText("")
         self.homeButton.setText("")
         self.SectionSensorConnection.setTitle(QCoreApplication.translate("sensor", u"Sensor Connection", None))
         self.connectButton.setText(QCoreApplication.translate("sensor", u"Connect", None))


### PR DESCRIPTION
## Summary
- fix image smoothing re-enable by updating the viewport
- move smoothing checkbox before stats button in the dock UI

## Testing
- `python3 -m py_compile ImageViewScene.py sensors.py sensorwindow_dock_ui.py`

------
https://chatgpt.com/codex/tasks/task_e_685502b9d8b483338a4a63bb968a169b